### PR TITLE
omit resource key from params if it is empty

### DIFF
--- a/main.py
+++ b/main.py
@@ -134,8 +134,8 @@ async def login_endpoint():
         "scope": CONFIG["SCOPE"],
     }
     # optional param for special cases
-    if "RESOURCE" in CONFIG:
-        params["resource"] = CONFIG["RESOURCE"]
+    if resource := CONFIG.get("RESOURCE", ""):
+        params["resource"] = resource
 
     # prepare the redirection response
     url = CONFIG["url_auth"] + "?" + urlencode(params)


### PR DESCRIPTION
There was an issue, that if `RESOURCE` env was not used, it would send AAI `resource: ""` which tried to validate the empty resource. Now the resource key is omitted if the env is not used.